### PR TITLE
Add non-breaking space before sorting symbols

### DIFF
--- a/src/Table.elm
+++ b/src/Table.elm
@@ -263,12 +263,12 @@ simpleTheadHelp ( name, status, click ) =
 
 darkGrey : String -> Html msg
 darkGrey symbol =
-    Html.span [ Attr.style "color" "#555" ] [ Html.text (" " ++ symbol) ]
+    Html.span [ Attr.style "color" "#555" ] [ Html.text ("\u{00A0}" ++ symbol) ]
 
 
 lightGrey : String -> Html msg
 lightGrey symbol =
-    Html.span [ Attr.style "color" "#ccc" ] [ Html.text (" " ++ symbol) ]
+    Html.span [ Attr.style "color" "#ccc" ] [ Html.text ("\u{00A0}" ++ symbol) ]
 
 
 simpleRowAttrs : data -> List (Attribute msg)


### PR DESCRIPTION
This ensures the first word of the column's title stays on the same line as the sorting symbol, instead of the latter being left alone =)